### PR TITLE
New methods: get and refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# vim
+.*.swp
+.*.swo
+.swp
+.swo

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ ESTester tests
 --------------
 
 In order to run ESTester tests, make sure you have ElasticSearch installed locally and it is up ::
+
     make setup
     make test
 

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -223,6 +223,7 @@ class ElasticSearchQueryTestCase(ExtendedTestCase):
         return json.loads(response.text)
 
     def get(self, doc_type, doc_id):
+        doc_id = urllib.quote_plus(doc_id)
         url = "{0}{1}/{2}/{3}".format(self.host, self.index, doc_type, doc_id)
         response = requests.get(url)
         if not response.status_code in [200, 201]:
@@ -396,6 +397,7 @@ class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
         return json.loads(response.text)
 
     def get(self, index, doc_type, doc_id):
+        doc_id = urllib.quote_plus(doc_id)
         url = "{0}{1}/{2}/{3}".format(self.host, index, doc_type, doc_id)
         response = requests.get(url)
         if not response.status_code in [200, 201]:

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -222,6 +222,14 @@ class ElasticSearchQueryTestCase(ExtendedTestCase):
             proxies=self.proxies)
         return json.loads(response.text)
 
+    def get(self, doc_type, doc_id):
+        url = "{0}{1}/{2}/{3}".format(self.host, self.index, doc_type, doc_id)
+        response = requests.get(url)
+        if not response.status_code in [200, 201]:
+            raise ElasticSearchException(response.text)
+        else:
+            return json.loads(response.text)
+
 
 class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
     """
@@ -386,3 +394,11 @@ class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
             data=json.dumps(query),
             proxies=self.proxies)
         return json.loads(response.text)
+
+    def get(self, index, doc_type, doc_id):
+        url = "{0}{1}/{2}/{3}".format(self.host, index, doc_type, doc_id)
+        response = requests.get(url)
+        if not response.status_code in [200, 201]:
+            raise ElasticSearchException(response.text)
+        else:
+            return json.loads(response.text)

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -223,8 +223,10 @@ class ElasticSearchQueryTestCase(ExtendedTestCase):
         return json.loads(response.text)
 
     def get(self, doc_type, doc_id):
+        index = urllib.quote_plus(self.index)
+        doc_type = urllib.quote_plus(doc_type)
         doc_id = urllib.quote_plus(doc_id)
-        url = "{0}{1}/{2}/{3}".format(self.host, self.index, doc_type, doc_id)
+        url = "{0}{1}/{2}/{3}".format(self.host, index, doc_type, doc_id)
         response = requests.get(url)
         if not response.status_code in [200, 201]:
             raise ElasticSearchException(response.text)
@@ -397,6 +399,8 @@ class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
         return json.loads(response.text)
 
     def get(self, index, doc_type, doc_id):
+        index = urllib.quote_plus(index)
+        doc_type = urllib.quote_plus(doc_type)
         doc_id = urllib.quote_plus(doc_id)
         url = "{0}{1}/{2}/{3}".format(self.host, index, doc_type, doc_id)
         response = requests.get(url)

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -353,7 +353,10 @@ class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
         """
         url = '{0}{1}/_aliases'.format(self.host, index)
         response = requests.get(url, proxies=self.proxies)
-        if not response.status_code in [200, 201]:
+        # Elasticsearch 0.90 used to return 404 when there were no aliases
+        if response.status_code == 404:
+            return []
+        elif not response.status_code in [200, 201]:
             raise ElasticSearchException(response.text)
         else:
             aliases = json.loads(response.text)

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -183,7 +183,10 @@ class ElasticSearchQueryTestCase(ExtendedTestCase):
                 proxies=self.proxies)
             if not response.status_code in [200, 201]:
                 raise ElasticSearchException(response.text)
-        time.sleep(self.timeout)
+        if self.timeout is None:
+            self.refresh()
+        else:
+            time.sleep(self.timeout)
         # http://0.0.0.0:9200/sample.test/_search
 
     def delete_index(self):
@@ -345,7 +348,10 @@ class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
                 proxies=self.proxies)
             if not response.status_code in [200, 201]:
                 raise ElasticSearchException(response.text)
-        time.sleep(self.timeout)
+        if self.timeout is None:
+            self.refresh_index(index_name)
+        else:
+            time.sleep(self.timeout)
         # http://0.0.0.0:9200/sample.test/_search
 
     def delete_index(self, index_name=""):

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -354,7 +354,7 @@ class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
             index: name of the index to be deleted
         """
         index = index_name or self.index
-        url = "{0}{1}/".format(self.host, self.index)
+        url = "{0}{1}/".format(self.host, index)
         requests.delete(url, proxies=self.proxies)
 
     def search(self, query=None):

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -94,6 +94,32 @@ class ElasticSearchQueryTestCase(ExtendedTestCase):
         if self.reset_index:
             self.delete_index()
 
+    def refresh_index(self, index=None):
+        """
+        Calls ElasticSearch's _refresh method on <index>. If index is None,
+        then refresh is called on every index.
+
+        This method makes all operations performed since the last refresh
+        available for search.
+        """
+        if index is None:
+            url = "{0}_refresh".format(self.host)
+        else:
+            url = "{0}{1}/_refresh".format(self.host, index)
+        response = requests.post(url, proxies=self.proxies)
+        if response.status_code not in [200, 201]:
+            raise ElasticSearchException(response.text)
+        return json.loads(response.text)
+
+    def refresh(self):
+        """
+        Calls ElasticSearch's _refresh method on the test case default index.
+
+        This method makes all operations performed since the last refresh
+        available for search.
+        """
+        return self.refresh_index(self.index)
+
     def create_index(self):
         """
         Use the following class attributes:

--- a/estester/__init__.py
+++ b/estester/__init__.py
@@ -338,10 +338,12 @@ class MultipleIndexesQueryTestCase(ElasticSearchQueryTestCase):
         index = index_name or self.index
         url = url.format(self.host, index)
         data = {}
-        if self.mappings:
-            data["mappings"] = mappings or self.mappings
-        if self.settings:
-            data["settings"] = settings or self.settings
+        mappings = mappings or self.mappings
+        if mappings:
+            data["mappings"] = mappings
+        settings = settings or self.settings
+        if settings:
+            data["settings"] = settings
         json_data = json.dumps(data)
         response = requests.put(url, proxies=self.proxies, data=json_data)
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,0 +1,134 @@
+import json
+from operator import itemgetter
+from mock import patch
+from estester import MultipleIndexesQueryTestCase, ElasticSearchException
+
+
+class AliasMultipleIndexesTestCase(MultipleIndexesQueryTestCase):
+
+    data = {
+        "beatles": {
+            "aliases": [
+                "band"
+            ],
+            "fixtures": [
+                {
+                    "type": "member",
+                    "id": "lenon",
+                    "body": {
+                        "name": "John Lenon",
+                        "role": "singer"
+                    }
+                },
+                {
+                    "type": "member",
+                    "id": "mccartney",
+                    "body": {
+                        "name": "Paul McCartney",
+                        "role": "guitar"
+                    }
+                },
+                {
+                    "type": "member",
+                    "id": "harrison",
+                    "body": {
+                        "name": "George Harrison",
+                        "role": "bass"
+                    }
+                }
+            ]
+        },
+        "thepolice": {
+            "aliases": [
+                "band",
+                "single-man-band"
+            ],
+            "fixtures": [
+                {
+                    "type": "member",
+                    "id": "sting",
+                    "body": {
+                        "name": "Gordon Matthew Thomas Sumner",
+                        "role": "singer"
+                    }
+                }
+            ]
+        }
+    }
+    timeout = None
+
+    def test_finds_aliases_for_all_indices(self):
+        self.assertEqual(set(self.get_aliases("thepolice")),
+                         {"band", "single-man-band"})
+        self.assertEqual(self.get_aliases("beatles"), ["band"])
+
+    def test_create_alias_for_an_index(self):
+        self.create_aliases('thepolice', ['stingband'])
+        self.assertEqual(set(self.get_aliases('thepolice')),
+                         {'band', 'single-man-band', 'stingband'})
+
+    def test_get_aliases_on_missing_index_must_return_empty(self):
+        self.assertEqual(self.get_aliases('hoodoogurus'), [])
+
+    def test_get_aliases_on_index_with_no_aliases_must_return_empty(self):
+        self.create_index('metallica')
+        self.assertEqual(self.get_aliases('metallica'), [])
+
+    # I could not make elasticsearch's _aliases to return an error
+    @patch('requests.get')
+    def test_failure_in_getting_alias(self, get):
+        attrs = {
+            "text": 'Error',
+            "status_code": 400
+        }
+        get.return_value.configure_mock(**attrs)
+        with self.assertRaises(ElasticSearchException) as cm:
+            self.get_aliases('hoodoogurus')
+        self.assertEqual(cm.exception.message, 'Error')
+
+    def test_creating_alias_for_missing_index_must_fail(self):
+        with self.assertRaises(ElasticSearchException) as cm:
+            self.create_aliases('hoodoogurus', ['stingband'])
+        expected = {
+            "error": "IndexMissingException[[hoodoogurus] missing]",
+            "status": 404
+        }
+        self.assertDictEqual(json.loads(cm.exception.message), expected)
+
+    def test_search_alias_for_sting(self):
+        query = {
+            "query": {
+                "match": {
+                    "name": "Gordon"
+                }
+            }
+        }
+        response = self.search_in_index("single-man-band", query)
+        self.assertEqual(response["hits"]["total"], 1)
+        self.assertEqual(response['hits']['hits'][0]['_id'], 'sting')
+
+    def test_single_index_alias_must_return_only_one_singer(self):
+        query = {
+            "query": {
+                "match": {
+                    "role": "singer"
+                }
+            }
+        }
+        response = self.search_in_index('single-man-band', query)
+        self.assertEqual(response["hits"]["total"], 1)
+        self.assertEqual(response["hits"]["hits"][0]['_id'], 'sting')
+
+    def test_search_bands_for_singer(self):
+        query = {
+            "query": {
+                "match": {
+                    "role": "singer"
+                }
+            }
+        }
+        response = self.search_in_index('band', query)
+        self.assertEqual(response["hits"]["total"], 2)
+        ids = map(itemgetter('_id'), response["hits"]["hits"])
+        self.assertIn('sting', ids)
+        self.assertIn('lenon', ids)

--- a/tests/test_index_management.py
+++ b/tests/test_index_management.py
@@ -1,0 +1,144 @@
+import json
+import requests
+from estester import MultipleIndexesQueryTestCase, ElasticSearchQueryTestCase
+
+
+class IndexManagementSingleIndexTestCase(ElasticSearchQueryTestCase):
+
+    timeout = None
+    mappings = {
+        "moscow": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "geo_point"
+                }
+            }
+        }
+    }
+    settings = {
+        "index": {
+            "number_of_replicas": "4",
+            "number_of_shards": "7"
+        }
+    }
+    index = 'indexovisky'
+
+    def test_created_index_with_proper_mapping_and_settings(self):
+        url = "{0}{1}".format(self.host, self.index)
+        response = requests.head(url)
+        self.assertEqual(response.status_code, 200)
+
+        response = requests.get(url + '/_mapping')
+        self.assertEqual(response.status_code, 200)
+        expected = {
+            "indexovisky": {
+                "mappings": self.mappings
+            }
+        }
+        self.assertDictEqual(json.loads(response.text), expected)
+
+        response = requests.get(url + '/_settings')
+        self.assertEqual(response.status_code, 200)
+        found = json.loads(response.text)['indexovisky']['settings']
+        self.assertEqual(found['index']['number_of_replicas'], '4')
+        self.assertEqual(found['index']['number_of_shards'], '7')
+
+
+class IndexManagementMultipleIndexesTestCase(MultipleIndexesQueryTestCase):
+
+    timeout = None
+    mappings = {
+        "moscow": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "geo_point"
+                }
+            }
+        }
+    }
+    settings = {
+        "index": {
+            "number_of_replicas": "4",
+            "number_of_shards": "7"
+        }
+    }
+
+    def setUp(self):
+        self.new_index = 'indexovisky'
+        self.url = '{0}{1}'.format(self.host, self.new_index)
+
+    def tearDown(self):
+        requests.delete(self.url)
+
+    def test_create_an_index_with_default_mappings_and_settings(self):
+        self.create_index(self.new_index)
+        response = requests.head(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        response = requests.get(self.url + '/_mapping')
+        self.assertEqual(response.status_code, 200)
+        expected = {
+            "indexovisky": {
+                "mappings": self.mappings
+            }
+        }
+        self.assertDictEqual(json.loads(response.text), expected)
+
+        response = requests.get(self.url + '/_settings')
+        self.assertEqual(response.status_code, 200)
+        found = json.loads(response.text)['indexovisky']['settings']
+        self.assertEqual(found['index']['number_of_replicas'], '4')
+        self.assertEqual(found['index']['number_of_shards'], '7')
+
+    def test_create_an_index_with_custom_mappings(self):
+        mappings = {
+            "mother_russia_people": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "age": {
+                        "type": "integer"
+                    }
+                }
+            }
+        }
+        self.create_index(self.new_index, mappings=mappings)
+        response = requests.head(self.url)
+        self.assertEqual(response.status_code, 200)
+        response = requests.get(self.url + '/_mapping')
+        self.assertEqual(response.status_code, 200)
+        expected = {
+            "indexovisky": {
+                "mappings": mappings
+            }
+        }
+        self.assertDictEqual(json.loads(response.text), expected)
+
+    def test_create_an_index_with_custom_settings(self):
+        settings = {
+            "index": {
+                "number_of_replicas": 2,
+                "number_of_shards": 3
+            }
+        }
+        self.create_index(self.new_index, settings=settings)
+        response = requests.head(self.url)
+        self.assertEqual(response.status_code, 200)
+        response = requests.get(self.url + '/_settings')
+        self.assertEqual(response.status_code, 200)
+        found = json.loads(response.text)['indexovisky']['settings']
+        self.assertEqual(found['index']['number_of_replicas'], '2')
+        self.assertEqual(found['index']['number_of_shards'], '3')
+
+    def test_delete_index(self):
+        requests.put(self.url)
+        self.delete_index(self.new_index)
+        response = requests.head(self.url)
+        self.assertEqual(response.status_code, 404)

--- a/tests/test_index_management.py
+++ b/tests/test_index_management.py
@@ -33,18 +33,30 @@ class IndexManagementSingleIndexTestCase(ElasticSearchQueryTestCase):
 
         response = requests.get(url + '/_mapping')
         self.assertEqual(response.status_code, 200)
-        expected = {
-            "indexovisky": {
-                "mappings": self.mappings
+        found = json.loads(response.text)
+        # Elasticsearch 0.90 did not return a mappings key
+        if 'mappings' in found['indexovisky']:
+            expected = {
+                "indexovisky": {
+                    "mappings": self.mappings
+                }
             }
-        }
-        self.assertDictEqual(json.loads(response.text), expected)
+        else:
+            expected = {
+                "indexovisky": self.mappings
+            }
+        self.assertDictEqual(found, expected)
 
         response = requests.get(url + '/_settings')
         self.assertEqual(response.status_code, 200)
         found = json.loads(response.text)['indexovisky']['settings']
-        self.assertEqual(found['index']['number_of_replicas'], '4')
-        self.assertEqual(found['index']['number_of_shards'], '7')
+        # Elasticsearch 0.90 used to use dot instead of nested dictionaries
+        if 'index' not in found:
+            self.assertEqual(found['index.number_of_replicas'], '4')
+            self.assertEqual(found['index.number_of_shards'], '7')
+        else:
+            self.assertEqual(found['index']['number_of_replicas'], '4')
+            self.assertEqual(found['index']['number_of_shards'], '7')
 
 
 class IndexManagementMultipleIndexesTestCase(MultipleIndexesQueryTestCase):
@@ -83,18 +95,30 @@ class IndexManagementMultipleIndexesTestCase(MultipleIndexesQueryTestCase):
 
         response = requests.get(self.url + '/_mapping')
         self.assertEqual(response.status_code, 200)
-        expected = {
-            "indexovisky": {
-                "mappings": self.mappings
+        found = json.loads(response.text)
+        # Elasticsearch 0.90 did not return a mappings key
+        if 'mappings' in found['indexovisky']:
+            expected = {
+                "indexovisky": {
+                    "mappings": self.mappings
+                }
             }
-        }
-        self.assertDictEqual(json.loads(response.text), expected)
+        else:
+            expected = {
+                "indexovisky": self.mappings
+            }
+        self.assertDictEqual(found, expected)
 
         response = requests.get(self.url + '/_settings')
         self.assertEqual(response.status_code, 200)
         found = json.loads(response.text)['indexovisky']['settings']
-        self.assertEqual(found['index']['number_of_replicas'], '4')
-        self.assertEqual(found['index']['number_of_shards'], '7')
+        # Elasticsearch 0.90 used to use dot instead of nested dictionaries
+        if 'index' not in found:
+            self.assertEqual(found['index.number_of_replicas'], '4')
+            self.assertEqual(found['index.number_of_shards'], '7')
+        else:
+            self.assertEqual(found['index']['number_of_replicas'], '4')
+            self.assertEqual(found['index']['number_of_shards'], '7')
 
     def test_create_an_index_with_custom_mappings(self):
         mappings = {
@@ -114,12 +138,19 @@ class IndexManagementMultipleIndexesTestCase(MultipleIndexesQueryTestCase):
         self.assertEqual(response.status_code, 200)
         response = requests.get(self.url + '/_mapping')
         self.assertEqual(response.status_code, 200)
-        expected = {
-            "indexovisky": {
-                "mappings": mappings
+        found = json.loads(response.text)
+        # Elasticsearch 0.90 did not return a mappings key
+        if 'mappings' in found['indexovisky']:
+            expected = {
+                "indexovisky": {
+                    "mappings": mappings
+                }
             }
-        }
-        self.assertDictEqual(json.loads(response.text), expected)
+        else:
+            expected = {
+                "indexovisky": mappings
+            }
+        self.assertDictEqual(found, expected)
 
     def test_create_an_index_with_custom_settings(self):
         settings = {
@@ -134,8 +165,13 @@ class IndexManagementMultipleIndexesTestCase(MultipleIndexesQueryTestCase):
         response = requests.get(self.url + '/_settings')
         self.assertEqual(response.status_code, 200)
         found = json.loads(response.text)['indexovisky']['settings']
-        self.assertEqual(found['index']['number_of_replicas'], '2')
-        self.assertEqual(found['index']['number_of_shards'], '3')
+        # Elasticsearch 0.90 used to use dot instead of nested dictionaries
+        if 'index' not in found:
+            self.assertEqual(found['index.number_of_replicas'], '2')
+            self.assertEqual(found['index.number_of_shards'], '3')
+        else:
+            self.assertEqual(found['index']['number_of_replicas'], '2')
+            self.assertEqual(found['index']['number_of_shards'], '3')
 
     def test_delete_index(self):
         requests.put(self.url)

--- a/tests/test_loadfixtures.py
+++ b/tests/test_loadfixtures.py
@@ -1,0 +1,112 @@
+from mock import patch
+from estester import ElasticSearchQueryTestCase, MultipleIndexesQueryTestCase
+
+
+class MultipleIndexesFixtureLoadingTestCase(MultipleIndexesQueryTestCase):
+
+    data = {
+        "personal": {
+            "fixtures": [
+                {
+                    "type": "contact",
+                    "id": "1",
+                    "body": {"name": "Dmitriy"}
+                },
+                {
+                    "type": "contact",
+                    "id": "2",
+                    "body": {"name": "Agnessa"}
+                }
+            ]
+        },
+        "professional": {
+            "fixtures": [
+                {
+                    "type": "contact",
+                    "id": "1",
+                    "body": {"name": "Nikolay"}
+                }
+            ]
+        },
+        "magical": {
+            "fixtures": [
+                {
+                    "type": "wizard/mage",
+                    "id": "http://middleearth.com/gandalf",
+                    "body": {"name": "Gandalf the Grey"}
+                }
+            ]
+        }
+    }
+    timeout = None
+
+    # Avoid that load_fixtures is called before every test
+    def _pre_setup(self):
+        for index_name, index in self.data.items():
+            if self.reset_index:
+                self.delete_index(index_name)
+            settings = index.get("settings", {})
+            mappings = index.get("mappings", {})
+            self.create_index(index_name, settings, mappings)
+
+    def test_load_fixtures_sets_all_documents_in_place(self):
+        loaded_fixtures = 0
+        for index_name, index in self.data.items():
+            self.load_fixtures(index_name, index['fixtures'])
+            response = self.search()
+            loaded_fixtures += len(index['fixtures'])
+            self.assertEqual(response["hits"]["total"], loaded_fixtures)
+
+    @patch('time.sleep')
+    def test_assert_that_timeout_is_being_waited_by_load_fixtures(self, sleep):
+        old_timeout = self.timeout
+        try:
+            self.timeout = 5
+            index_name, index = self.data.items()[0]
+            self.load_fixtures(index_name, index['fixtures'])
+            sleep.assert_called_once_with(5)
+        finally:
+            self.timeout = old_timeout
+
+
+class SingleIndexFixtureLoadingTestCase(ElasticSearchQueryTestCase):
+
+    fixtures = [
+        {
+            "type": "dog",
+            "id": "1",
+            "body": {"name": "Nina Fox"}
+        },
+        {
+            "type": "dog",
+            "id": "2",
+            "body": {"name": "Charles M."}
+        },
+        {
+            "type": "internet/dog",
+            "id": "http://dog.com",
+            "body": {"name": "It bytes"}
+        }
+    ]
+    timeout = None
+
+    # Avoid that load_fixtures is called before every test
+    def _pre_setup(self):
+        if self.reset_index:
+            self.delete_index()
+        self.create_index()
+
+    def test_load_fixtures_sets_all_documents_in_place(self):
+        self.load_fixtures()
+        response = self.search()
+        self.assertEqual(response["hits"]["total"], len(self.fixtures))
+
+    @patch('time.sleep')
+    def test_assert_that_timeout_is_being_waited_by_load_fixtures(self, sleep):
+        old_timeout = self.timeout
+        try:
+            self.timeout = 5
+            self.load_fixtures()
+            sleep.assert_called_once_with(5)
+        finally:
+            self.timeout = old_timeout

--- a/tests/test_querytestcase.py
+++ b/tests/test_querytestcase.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 import time
 import requests
 from mock import patch
@@ -235,14 +236,25 @@ class SimpleMultipleIndexesQueryTestCase(MultipleIndexesQueryTestCase):
                 "name": "Dmitriy"
             }
         }
+        # Compatibility with elasticsearch 0.90
+        if 'exists' in response:
+            expected['exists'] = expected.pop('found')
         self.assertDictEqual(response, expected)
 
     def test_get_exception_on_missing_document(self):
         with self.assertRaises(ElasticSearchException) as cm:
             self.get('personal', 'contact', '20')
-        expected = \
-            '{"_index":"personal","_type":"contact","_id":"20","found":false}'
-        self.assertEqual(cm.exception.message, expected)
+        expected = {
+            "_index": "personal",
+            "_type": "contact",
+            "_id": "20",
+            "found": False
+        }
+        response = json.loads(cm.exception.message)
+        # Compatibility with elasticsearch 0.90
+        if 'exists' in response:
+            expected['exists'] = expected.pop('found')
+        self.assertEqual(response, expected)
 
 
 class SimpleQueryTestCase(ElasticSearchQueryTestCase):
@@ -311,14 +323,25 @@ class SimpleQueryTestCase(ElasticSearchQueryTestCase):
                 "name": "Nina Fox"
             }
         }
+        # Compatibility with elasticsearch 0.90
+        if 'exists' in response:
+            expected['exists'] = expected.pop('found')
         self.assertDictEqual(response, expected)
 
     def test_get_exception_on_missing_document(self):
         with self.assertRaises(ElasticSearchException) as cm:
             self.get('dog', '20')
-        expected = \
-            '{"_index":"sample.test","_type":"dog","_id":"20","found":false}'
-        self.assertEqual(cm.exception.message, expected)
+        expected = {
+            "_index": "sample.test",
+            "_type": "dog",
+            "_id": "20",
+            "found": False
+        }
+        response = json.loads(cm.exception.message)
+        # Compatibility with elasticsearch 0.90
+        if 'exists' in response:
+            expected['exists'] = expected.pop('found')
+        self.assertEqual(response, expected)
 
     def test_tokenize_with_default_analyzer(self):
         response = self.tokenize("Nothing to declare", "default")

--- a/tests/test_querytestcase.py
+++ b/tests/test_querytestcase.py
@@ -223,6 +223,27 @@ class SimpleMultipleIndexesQueryTestCase(MultipleIndexesQueryTestCase):
         response = self.search_in_index("professional", query)
         self.assertEqual(response["hits"]["total"], 0)
 
+    def test_get_correct_document(self):
+        response = self.get('personal', 'contact', '1')
+        expected = {
+            "_index": "personal",
+            "_type": "contact",
+            "_id": "1",
+            "_version": 1,
+            "found": True,
+            "_source": {
+                "name": "Dmitriy"
+            }
+        }
+        self.assertDictEqual(response, expected)
+
+    def test_get_exception_on_missing_document(self):
+        with self.assertRaises(ElasticSearchException) as cm:
+            self.get('personal', 'contact', '20')
+        expected = \
+            '{"_index":"personal","_type":"contact","_id":"20","found":false}'
+        self.assertEqual(cm.exception.message, expected)
+
 
 class SimpleQueryTestCase(ElasticSearchQueryTestCase):
 
@@ -277,6 +298,27 @@ class SimpleQueryTestCase(ElasticSearchQueryTestCase):
         self.assertEqual(response["hits"]["total"], 1)
         self.assertEqual(response["hits"]["hits"][0]["_id"], u"1")
         self.assertEqual(response["hits"]["hits"][0]["_source"], expected)
+
+    def test_get_correct_document(self):
+        response = self.get('dog', '1')
+        expected = {
+            "_index": "sample.test",
+            "_type": "dog",
+            "_id": "1",
+            "_version": 1,
+            "found": True,
+            "_source": {
+                "name": "Nina Fox"
+            }
+        }
+        self.assertDictEqual(response, expected)
+
+    def test_get_exception_on_missing_document(self):
+        with self.assertRaises(ElasticSearchException) as cm:
+            self.get('dog', '20')
+        expected = \
+            '{"_index":"sample.test","_type":"dog","_id":"20","found":false}'
+        self.assertEqual(cm.exception.message, expected)
 
     def test_tokenize_with_default_analyzer(self):
         response = self.tokenize("Nothing to declare", "default")

--- a/tests/test_querytestcase.py
+++ b/tests/test_querytestcase.py
@@ -30,9 +30,9 @@ SINGLE_INDEX_FIXTURE = [
         "body": {"name": "Charles M."}
     },
     {
-        "type": "dog",
+        "type": "internet/dog",
         "id": "http://dog.com",
-        "body": {"name": "Internet dog"}
+        "body": {"name": "It bytes"}
     }
 ]
 MULTIPLE_INDEXES_FIXTURE = {
@@ -62,7 +62,7 @@ MULTIPLE_INDEXES_FIXTURE = {
     "magical": {
         "fixtures": [
             {
-                "type": "wizard",
+                "type": "wizard/mage",
                 "id": "http://middleearth.com/gandalf",
                 "body": {"name": "Gandalf the Grey"}
             }
@@ -214,7 +214,7 @@ class SimpleMultipleIndexesQueryTestCase(MultipleIndexesQueryTestCase):
             },
             {
                 u'_score': 1.0,
-                u'_type': u'wizard',
+                u'_type': u'wizard/mage',
                 u'_index': u'magical',
                 u'_id': u'http://middleearth.com/gandalf',
                 u'_source': {u'name': u'Gandalf the Grey'}
@@ -265,11 +265,12 @@ class SimpleMultipleIndexesQueryTestCase(MultipleIndexesQueryTestCase):
         self.assertDictEqual(response, expected)
 
     def test_get_document_with_url_id(self):
-        response = \
-            self.get('magical', 'wizard', 'http://middleearth.com/gandalf')
+        response = self.get('magical',
+                            'wizard/mage',
+                            'http://middleearth.com/gandalf')
         expected = {
             "_index": "magical",
-            "_type": "wizard",
+            "_type": "wizard/mage",
             "_id": "http://middleearth.com/gandalf",
             "_version": 1,
             "found": True,
@@ -372,15 +373,15 @@ class SimpleQueryTestCase(ElasticSearchQueryTestCase):
         self.assertDictEqual(response, expected)
 
     def test_get_document_with_url_id(self):
-        response = self.get('dog', 'http://dog.com')
+        response = self.get('internet/dog', 'http://dog.com')
         expected = {
             "_index": "sample.test",
-            "_type": "dog",
+            "_type": "internet/dog",
             "_id": "http://dog.com",
             "_version": 1,
             "found": True,
             "_source": {
-                "name": "Internet dog"
+                "name": "It bytes"
             }
         }
         # Compatibility with elasticsearch 0.90

--- a/tests/test_querytestcase.py
+++ b/tests/test_querytestcase.py
@@ -104,7 +104,7 @@ class SimpleMultipleIndexesQueryTestCase(MultipleIndexesQueryTestCase):
     def test_search_one_index_that_has_item(self):
         query = {
             "query": {
-                "text": {
+                "match": {
                     "name": "Agnessa"
                 }
             }
@@ -117,7 +117,7 @@ class SimpleMultipleIndexesQueryTestCase(MultipleIndexesQueryTestCase):
     def test_search_one_index_that_doesnt_have_item(self):
         query = {
             "query": {
-                "text": {
+                "match": {
                     "name": "Agnessa"
                 }
             }

--- a/tests/test_querytestcase.py
+++ b/tests/test_querytestcase.py
@@ -101,6 +101,136 @@ class DefaultValuesTestCase(unittest.TestCase):
         self.assertEqual(ESQTC.proxies, {})
 
 
+class AliasMultipleIndexesTestCase(MultipleIndexesQueryTestCase):
+
+    data = {
+        "beatles": {
+            "aliases": [
+                "band"
+            ],
+            "fixtures": [
+                {
+                    "type": "member",
+                    "id": "lenon",
+                    "body": {
+                        "name": "John Lenon",
+                        "role": "singer"
+                    }
+                },
+                {
+                    "type": "member",
+                    "id": "mccartney",
+                    "body": {
+                        "name": "Paul McCartney",
+                        "role": "guitar"
+                    }
+                },
+                {
+                    "type": "member",
+                    "id": "harrison",
+                    "body": {
+                        "name": "George Harrison",
+                        "role": "bass"
+                    }
+                }
+            ]
+        },
+        "thepolice": {
+            "aliases": [
+                "band",
+                "single-man-band"
+            ],
+            "fixtures": [
+                {
+                    "type": "member",
+                    "id": "sting",
+                    "body": {
+                        "name": "Gordon Matthew Thomas Sumner",
+                        "role": "singer"
+                    }
+                }
+            ]
+        }
+    }
+    timeout = None
+
+    def test_finds_aliases_for_all_indices(self):
+        self.assertEqual(set(self.get_aliases("thepolice")),
+                         {"band", "single-man-band"})
+        self.assertEqual(self.get_aliases("beatles"), ["band"])
+
+    def test_create_alias_for_an_index(self):
+        self.create_aliases('thepolice', ['stingband'])
+        self.assertEqual(set(self.get_aliases('thepolice')),
+                         {'band', 'single-man-band', 'stingband'})
+
+    def test_get_aliases_on_missing_index_must_return_empty(self):
+        self.assertEqual(self.get_aliases('hoodoogurus'), [])
+
+    def test_get_aliases_on_index_with_no_aliases_must_return_empty(self):
+        self.create_index('metallica')
+        self.assertEqual(self.get_aliases('metallica'), [])
+
+    # I could not  make elasticsearch's _aliases to return an error
+    @patch('requests.get')
+    def test_failure_in_getting_alias(self, get):
+        attrs = {
+            "text": 'Error',
+            "status_code": 400
+        }
+        get.return_value.configure_mock(**attrs)
+        with self.assertRaises(ElasticSearchException) as cm:
+            self.get_aliases('hoodoogurus')
+        self.assertEqual(cm.exception.message, 'Error')
+
+    def test_creating_alias_for_missing_index_must_fail(self):
+        with self.assertRaises(ElasticSearchException) as cm:
+            self.create_aliases('hoodoogurus', ['stingband'])
+        expected = {
+            "error": "IndexMissingException[[hoodoogurus] missing]",
+            "status": 404
+        }
+        self.assertDictEqual(json.loads(cm.exception.message), expected)
+
+    def test_search_alias_for_sting(self):
+        query = {
+            "query": {
+                "match": {
+                    "name": "Gordon"
+                }
+            }
+        }
+        response = self.search_in_index("single-man-band", query)
+        self.assertEqual(response["hits"]["total"], 1)
+        self.assertEqual(response['hits']['hits'][0]['_id'], 'sting')
+
+    def test_single_index_alias_must_return_only_one_singer(self):
+        query = {
+            "query": {
+                "match": {
+                    "role": "singer"
+                }
+            }
+        }
+        response = self.search_in_index('single-man-band', query)
+        self.assertEqual(response["hits"]["total"], 1)
+        self.assertEqual(response["hits"]["hits"][0]['_id'], 'sting')
+
+    def test_search_bands_for_singer(self):
+        query = {
+            "query": {
+                "match": {
+                    "role": "singer"
+                }
+            }
+        }
+        response = self.search_in_index('band', query)
+        self.assertEqual(response["hits"]["total"], 2)
+        ids = map(itemgetter('_id'), response["hits"]["hits"])
+        self.assertIn('sting', ids)
+        self.assertIn('lenon', ids)
+
+
 class MultipleIndexesFixtureLoadingTestCase(MultipleIndexesQueryTestCase):
 
     data = MULTIPLE_INDEXES_FIXTURE


### PR DESCRIPTION
I've added elasticsearch's refresh and get methods. I think refresh may take the place of timeout. I kept timeout working how it was for backwards compatibility, but if timeout is set to None, then refresh is used.

I have also added support for creating aliases on MultipleIndexesQueryTestCase.
